### PR TITLE
Sequence exhaustion check fixes

### DIFF
--- a/checks.go
+++ b/checks.go
@@ -480,7 +480,7 @@ SELECT * FROM combined WHERE ratio < 0.99
 	SELECT ns.nspname||'.'||c.relname||'('||attname||')' as col, ns.nspname||'.'||s.relname as seq
 	FROM pg_attribute a
 	INNER JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
-	INNER JOIN pg_class s ON s.relkind = 'S' AND s.relname = regexp_replace(d.adsrc, $s$nextval\('(.*)'::regclass\)$$s$, '\1')
+	INNER JOIN pg_class s ON s.relkind = 'S' AND s.relname = regexp_replace(d.adsrc, $s$nextval\('"?(.*?)"?'::regclass\)$$s$, '\1')
 	INNER JOIN pg_class c ON c.oid = a.attrelid
 	INNER JOIN pg_namespace ns ON ns.oid = c.relnamespace
 	WHERE atttypid = 'int4'::regtype

--- a/checks.go
+++ b/checks.go
@@ -477,7 +477,8 @@ SELECT * FROM combined WHERE ratio < 0.99
 			;`
 
 	seqsOnInt4SQL = `
-	SELECT ns.nspname||'.'||c.relname||'('||attname||')' as col, ns.nspname||'.'||s.relname as seq
+	SELECT quote_ident(ns.nspname)||'.'||quote_ident(c.relname)||'('||quote_ident(attname)||')' as col,
+          quote_ident(ns.nspname)||'.'||quote_ident(s.relname) as seq
 	FROM pg_attribute a
 	INNER JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
 	INNER JOIN pg_class s ON s.relkind = 'S' AND s.relname = regexp_replace(d.adsrc, $s$nextval\('"?(.*?)"?'::regclass\)$$s$, '\1')


### PR DESCRIPTION
Previously the check query did not correctly handle sequences tied to columns whose name, associated table name, or associated table's schema name required quoting. This fixes the query to pick these up, and also quotes the associated identifiers to avoid a situation where `pg:diagnose` drops your tables if you name your sequence-dependent column, schema, or table something cute like `; drop table users; --`.